### PR TITLE
Fix SubCategory Listing Shows (No content found)

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -317,13 +317,13 @@ def SubCategory( title, name, url, page=1, **kwargs ):
                 show_url = BASE_URL + show_url
             if DEBUG_LEVEL > 1: Log.Debug(DBG( "    show_url   : %s" % (show_url) ))
 
-            show_image = show.xpath('./a/img/@src')[0]
+            show_image = show.xpath('./a/div/img/@src')[0]
             if DEBUG_LEVEL > 1: Log.Debug(DBG( "    show_image : %s" % (show_image) ))
 
             show_banner = show_image
             if DEBUG_LEVEL > 1: Log.Debug(DBG( "    show_banner: %s" % (show_banner) ))
 
-            show_blurb = show.xpath('./a/h3[@class="show-cover-thumb-aired-mobile"]/text()')[0]
+            show_blurb = show.xpath('./a/div/h3[@class="show-cover-thumb-aired-mobile"]/text()')[0]
             show_blurb = String.DecodeHTMLEntities( show_blurb ).strip()
             if DEBUG_LEVEL > 1: Log.Debug(DBG( "    show_blurb : %s" % (show_blurb) ))
 


### PR DESCRIPTION
Channel couldn't show content in SubCategories (Drama,Subbed Shows, etc..)

tfc.tv added an extra <div> tag which cause SubCategory() to hang and not display content

NEW:
<.li class="og-grid-item-o" data-title="Ikaw Lang Ang Iibigin" data-aired="20170426" data-episode="20180126">
	<.a href="/show/details/4323/ikaw-lang-ang-iibigin">
		<.div data-sid="4323">
			<.img src="https://img.tfc.tv/xcms/categoryimages/4323/IKAW-LANG-ANG-IIBIGIN-STANDARD-SHOW-THUMBNAIL_289x163.jpg" alt="Ikaw Lang Ang Iibigin 20180126"/>
			<.h2 class="show-cover-thumb-title-mobile sub-category">Ikaw Lang Ang Iibigin</h2>
			<.h3 class="show-cover-thumb-aired-mobile">AIRED: April 2017</h3>
		<./div>
	<./a>
<./li>

OLD:
<.li class="og-grid-item-o" data-title="Ikaw Lang Ang Iibigin" data-aired="20170426" data-episode="20180126">
	<.a href="/show/details/4323/ikaw-lang-ang-iibigin">
		<.img src="https://img.tfc.tv/xcms/categoryimages/4323/IKAW-LANG-ANG-IIBIGIN-STANDARD-SHOW-THUMBNAIL_289x163.jpg" alt="Ikaw Lang Ang Iibigin 20180126"/>
		<.h2 class="show-cover-thumb-title-mobile sub-category">Ikaw Lang Ang Iibigin</h2>
		<.h3 class="show-cover-thumb-aired-mobile">AIRED: April 2017</h3>
	<./a>
<./li>

Edit: Added dots to break html formatting to show significant changes